### PR TITLE
refactor: cleaner DSL

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :development do
   gem "sprockets-rails"
   gem "foreman"
   gem "github_changelog_generator", "~> 1.16"
+  gem "rspec"
 
   # gem 'better_errors'
   # gem 'binding_of_caller'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,7 @@ GEM
       json
     crass (1.0.6)
     date (3.3.4)
+    diff-lcs (1.5.1)
     drb (2.2.1)
     erubi (1.13.0)
     faraday (2.11.0)
@@ -262,6 +263,19 @@ GEM
     reline (0.5.9)
       io-console (~> 0.5)
     rouge (4.3.0)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.1)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
@@ -325,6 +339,7 @@ DEPENDENCIES
   github_changelog_generator (~> 1.16)
   phlex_storybook!
   puma
+  rspec
   sprockets-rails
   web-console
 

--- a/README.md
+++ b/README.md
@@ -81,24 +81,22 @@ with the storybook. E.g.
 
 ```ruby
 class HelloWorld < Phlex::HTML
-  register_component do
-    # component_category is optional, non-categorized components will appear under "Uncategorized"
-    component_category "Category 1"
+  storybook do
+    # category is optional, non-categorized components will appear under "Uncategorized"
+    category "Category 1"
 
-    # component_name is optional, it defaults to the name of your component
-    component_name "Good ol' Hello"
+    # name is optional, it defaults to the name of your component
+    name "Good ol' Hello"
 
-    # component_description is optional
-    component_description "The typical programmer's first attempt..."
+    # description is optional
+    description "The typical programmer's first attempt..."
 
-    # component props are required if your component takes arguments in #initialize
-    component_props [
-      PhlexStorybook::Props::String.new(key: :who, placeholder: "Who do you want to say hello to?")
-    ]
+    # props are required if your component takes arguments in #initialize
+    prop_string :who, placeholder: "Who do you want to say hello to?"
 
-    # component stories are optional; they are predefined instances of your component
-    component_stories "Arnold" => { who: "Arnie Schwarzenegger" },
-                      "Reagan" => { who: "Ronnie" }
+    # stories are optional; they are predefined instances of your component
+    story "Arnold", who: "Arnie Schwarzenegger"
+    story "Reagan", who: "Ronnie"
   end
 
   def initialize(who: "world")

--- a/lib/phlex_storybook.rb
+++ b/lib/phlex_storybook.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
+require "importmap-rails"
+require "phlex_icons"
+require "phlex-rails"
+require "phlex"
+require "rouge"
+require "stimulus-rails"
+require "turbo_power"
+require "turbo-rails"
+
 require "phlex_storybook/version"
 require "phlex_storybook/engine"
 require "phlex_storybook/configuration"
-
-# require "zeitwerk"
-
-# loader = Zeitwerk::Loader.new
-# loader.inflector = Zeitwerk::GemInflector.new(__FILE__)
-# loader.push_dir(File.expand_path("../app", __dir__))
-# loader.setup
 
 module PhlexStorybook
   autoload :DSL, "phlex_storybook/dsl"

--- a/lib/phlex_storybook/components/stories/component_properties.rb
+++ b/lib/phlex_storybook/components/stories/component_properties.rb
@@ -30,7 +30,7 @@ module PhlexStorybook
                   @story_component.props.each do |prop|
                     li do
                       label(class: 'grid grid-cols-1 w-full') do
-                        div { prop.label || prop.key.to_s.capitalize }
+                        div { prop.label }
                         render prop.clone_with_value(@props&.fetch(prop.key, nil))
                       end
                     end

--- a/lib/phlex_storybook/dsl.rb
+++ b/lib/phlex_storybook/dsl.rb
@@ -62,7 +62,7 @@ module PhlexStorybook
     end
 
     class_methods do
-      def register_component(&block)
+      def storybook(&block)
         source_location = block&.source_location || self.instance_method(:view_template)&.source_location
         PhlexStorybook.configuration.register(self, source_location).tap { |sc| sc.name = name }
 

--- a/lib/phlex_storybook/dsl.rb
+++ b/lib/phlex_storybook/dsl.rb
@@ -6,34 +6,67 @@ module PhlexStorybook
   module DSL
     extend ActiveSupport::Concern
 
+    class Proxy
+      def initialize(klass)
+        @klass           = klass
+        @story_component = PhlexStorybook.configuration.components[klass]
+      end
+
+      def category(v)
+        @story_component.category = v
+      end
+
+      def description(v)
+        @story_component.description = v
+      end
+
+      def lookup_prop_class(name)
+        PhlexStorybook::Props.const_get(name.to_s.sub('prop_', '').camelize)
+      end
+
+      def name(v)
+        @story_component.name = v
+      end
+
+      def prop(prop_class, key, **options)
+        @story_component.props << prop_class.new(key: key, **options)
+      end
+
+      def story(k, **props)
+        @story_component.stories[k] = props
+      end
+
+      private
+
+      def method_missing(name, *args, **kw_args, &block)
+        if @klass.respond_to?(name)
+          return @klass.send(name, *args, **kw_args, &block)
+        end
+
+        return super unless name.start_with?('prop_')
+
+        prop_class = lookup_prop_class(name)
+        if prop_class
+          prop(prop_class, args.first, **kw_args)
+        else
+          raise ArgumentError, "Unknown prop type: #{name}"
+        end
+      end
+
+      def respond_to_missing?(name, include_private = false)
+        return true if @klass.respond_to_missing?(name, include_private)
+        return false unless name.start_with?('prop_')
+
+        !!lookup_prop_class(name) || super
+      end
+    end
+
     class_methods do
-      def __find_registered__
-        PhlexStorybook.configuration.components[self]
-      end
-
-      def component_category(v)
-        __find_registered__.category = v
-      end
-
-      def component_description(v)
-        __find_registered__.description = v
-      end
-
-      def component_name(v)
-        __find_registered__.name = v
-      end
-
-      def component_props(v)
-        __find_registered__.props = v
-      end
-
-      def component_stories(v)
-        __find_registered__.stories = v
-      end
-
       def register_component(&block)
-        PhlexStorybook.configuration.register(self, block.source_location).tap { |sc| sc.name = name }
-        block.call
+        source_location = block&.source_location || self.instance_method(:view_template)&.source_location
+        PhlexStorybook.configuration.register(self, source_location).tap { |sc| sc.name = name }
+
+        Proxy.new(self).instance_eval(&block) if block
       end
     end
   end

--- a/lib/phlex_storybook/engine.rb
+++ b/lib/phlex_storybook/engine.rb
@@ -1,15 +1,5 @@
 require_relative "dsl"
 
-require "importmap-rails"
-require "turbo-rails"
-require "stimulus-rails"
-
-require "phlex"
-require "phlex_icons"
-require "phlex-rails"
-require "rouge"
-require "turbo_power"
-
 module PhlexStorybook
   class Engine < ::Rails::Engine
     isolate_namespace PhlexStorybook

--- a/lib/phlex_storybook/props/base.rb
+++ b/lib/phlex_storybook/props/base.rb
@@ -6,9 +6,9 @@ module PhlexStorybook
       def initialize(key:, default: nil, label: nil, placeholder: nil, required: false)
         @key         = key
         @default     = default
-        @label       = label
+        @label       = label || key.to_s.humanize.split.map(&:capitalize).join(" ")
         @placeholder = placeholder
-        @required    = required
+        @required    = !!required
         @value       = nil
       end
 

--- a/lib/phlex_storybook/props/select.rb
+++ b/lib/phlex_storybook/props/select.rb
@@ -5,8 +5,8 @@ module PhlexStorybook
 
       def self.default = []
 
-      def initialize(key:, options:, label: nil, include_blank: false, multiple: false, placeholder: nil, required: nil)
-        super(key: key, label: label, placeholder: placeholder, required: required)
+      def initialize(key:, options:, include_blank: false, multiple: false, **base_opts)
+        super(key: key, **base_opts)
         @include_blank = include_blank
         @multiple = multiple
         @options = options

--- a/lib/phlex_storybook/tasks/install.rb
+++ b/lib/phlex_storybook/tasks/install.rb
@@ -13,12 +13,15 @@ module PhlexStorybook
           <<~RUBY
             # frozen_string_literal: true
             #
-            # Make sure to add register_component blocks to your components
+            # Make sure to add the DSL and invoke ".storybook" in your components
             #
             # Example:
-            # register_component do
-            #   component_category "Category 1"
-            # end
+            #   class DummyComponent < Phlex::HTML
+            #     include PhlexStorybook::DSL
+            #     storybook do
+            #       category "Category 1"
+            #     end
+            #   end
 
             Dir[Rails.root.join("app/components/**/*.rb").to_s].each { |file| require file }
           RUBY

--- a/spec/lib/phlex_storybook/dsl_spec.rb
+++ b/spec/lib/phlex_storybook/dsl_spec.rb
@@ -4,7 +4,7 @@ describe PhlexStorybook::DSL do
   class TestComponentOne < Phlex::HTML
     include PhlexStorybook::DSL
 
-    register_component do
+    storybook do
       name 'Test Component'
       description 'This is a test component'
       category 'Test'
@@ -29,7 +29,7 @@ describe PhlexStorybook::DSL do
   class TestComponentTwo < Phlex::HTML
     include PhlexStorybook::DSL
 
-    register_component
+    storybook
 
     def view_template
       div { "testing" }

--- a/spec/lib/phlex_storybook/dsl_spec.rb
+++ b/spec/lib/phlex_storybook/dsl_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+describe PhlexStorybook::DSL do
+  class TestComponentOne < Phlex::HTML
+    include PhlexStorybook::DSL
+
+    register_component do
+      name 'Test Component'
+      description 'This is a test component'
+      category 'Test'
+      prop_boolean :bool, default: true
+      prop_string :str, label: 'String'
+      prop_text :txt
+      prop_select :single_select, options: %w[baz blat], required: true, label: 'SS', include_blank: true
+      prop_select :multiple_select, multiple: true, options: %w[foo bar], default: %w[foo]
+      story 'Bar', single_select: 'blat'
+      story 'Baz', single_select: 'baz', multiple_select: %w[foo]
+    end
+
+    def initialize(bool:, str:, txt:, single_select:, multiple_select:)
+      @str = str
+    end
+
+    def view_template
+      div
+    end
+  end
+
+  class TestComponentTwo < Phlex::HTML
+    include PhlexStorybook::DSL
+
+    register_component
+
+    def view_template
+      div { "testing" }
+    end
+  end
+
+  let(:comp_one) { PhlexStorybook.configuration.components[TestComponentOne] }
+  let(:comp_two) { PhlexStorybook.configuration.components[TestComponentTwo] }
+
+  it 'registers the component' do
+    expect(comp_one).to be_a(PhlexStorybook::StoryComponent)
+    expect(comp_two).to be_a(PhlexStorybook::StoryComponent)
+  end
+
+  it 'registers the component with the correct name' do
+    expect(comp_one.name).to eq('Test Component')
+    expect(comp_two.name).to eq('TestComponentTwo')
+  end
+
+  it 'registers the component with the correct description' do
+    expect(comp_one.description).to eq('This is a test component')
+    expect(comp_two.description).to eq('No description provided')
+  end
+
+  it 'registers the component with the correct category' do
+    expect(comp_one.category).to eq('Test')
+    expect(comp_two.category).to eq('Uncategorized')
+  end
+
+  it 'registers the component with the correct stories' do
+    expect(comp_one.stories.keys).to eq(%w[Bar Baz])
+    expect(comp_two.stories.keys).to be_empty
+  end
+
+  it 'registers the component with the correct props' do
+    aggregate_failures do
+      expect(comp_one.props.map(&:key)).to(
+        eq(%i[bool str txt single_select multiple_select])
+      )
+      expect(comp_one.props.map(&:label)).to(
+        eq(['Bool', 'String', 'Txt', 'SS', 'Multiple Select'])
+      )
+      expect(comp_one.props.map(&:required)).to eq([false, false, false, true, false])
+      expect(comp_one.props.first.default).to eq(true)
+      expect(comp_one.props.last.default).to eq(%w[foo])
+      expect(comp_one.props[-2..-1].map(&:multiple)).to eq([false, true])
+      expect(comp_one.props[-2..-1].map(&:include_blank)).to eq([true, false])
+
+      expect(comp_two.props).to be_empty
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,20 @@
+#frozen_string_literal: true
+
+ENV["RAILS_ENV"] ||= "test"
+
+require 'rspec'
+require File.expand_path("../test/dummy/config/application", __dir__)
+
+require_relative "../lib/phlex_storybook"
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end

--- a/test/dummy/app/components/another_dummy_component.rb
+++ b/test/dummy/app/components/another_dummy_component.rb
@@ -12,9 +12,9 @@ class AnotherDummyComponent < Phlex::HTML
   end
 
   register_component do
-    component_category "Category 2"
+    category "Category 2"
 
-    component_description <<~TEXT
+    description <<~TEXT
       Lorem ipsum dolor sit amet, consectetur adipiscing elit.
       Morbi hendrerit libero euismod nisl venenatis sollicitudin.
       Curabitur in leo vel justo vulputate ornare at id dolor.
@@ -36,16 +36,14 @@ class AnotherDummyComponent < Phlex::HTML
       Sed imperdiet risus sit amet mi rutrum luctus.
     TEXT
 
-    component_props [
-      PhlexStorybook::Props::String.new(key: :header, placeholder: "The header", required: true),
-      PhlexStorybook::Props::Text.new(key: :text, label: "The list"),
-      PhlexStorybook::Props::Boolean.new(key: :truthy, label: "Truthy"),
-      PhlexStorybook::Props::Select.new(key: :selectable, label: "Select", include_blank: true, options: %w[Option1 Option2 Option3]),
-      PhlexStorybook::Props::Select.new(key: :multi_selectable, label: "Select Several", multiple: true, options: %w[Option1 Option2 Option3]),
-    ]
+    prop_string :header, placeholder: "The header", required: true
+    prop_text :text, label: "The list"
+    prop_boolean :truthy, label: "Truthy"
+    prop_select :selectable, label: "Select", include_blank: true, options: %w[Option1 Option2 Option3]
+    prop_select :multi_selectable, label: "Select Several", multiple: true, options: %w[Option1 Option2 Option3]
 
-    component_stories "Short List" => { header: "Candidates", text: short_string, truthy: true },
-                      "Still Deciding" => { header: "Things", text: long_string, truthy: false }
+    story "Short List", header: "Candidates", text: short_string, truthy: true
+    story "Still Deciding", header: "Things", text: long_string, truthy: false
   end
 
   def initialize(header:, text: "", truthy: false, selectable: [], multi_selectable: [])

--- a/test/dummy/app/components/another_dummy_component.rb
+++ b/test/dummy/app/components/another_dummy_component.rb
@@ -11,7 +11,7 @@ class AnotherDummyComponent < Phlex::HTML
     3.times.map { |i| "Candidate #{i + 1}" }.join("\n")
   end
 
-  register_component do
+  storybook do
     category "Category 2"
 
     description <<~TEXT

--- a/test/dummy/app/components/dummy_component.rb
+++ b/test/dummy/app/components/dummy_component.rb
@@ -3,7 +3,7 @@
 class DummyComponent < Phlex::HTML
   include PhlexStorybook::DSL
 
-  register_component do
+  storybook do
     category "Category 1"
     description "This is a dummy component"
     name "Dummy Component"

--- a/test/dummy/app/components/dummy_component.rb
+++ b/test/dummy/app/components/dummy_component.rb
@@ -4,9 +4,9 @@ class DummyComponent < Phlex::HTML
   include PhlexStorybook::DSL
 
   register_component do
-    component_category "Category 1"
-    component_description "This is a dummy component"
-    component_name "Dummy Component"
+    category "Category 1"
+    description "This is a dummy component"
+    name "Dummy Component"
   end
 
   def view_template

--- a/test/dummy/app/components/rendered_results_preview_component.rb
+++ b/test/dummy/app/components/rendered_results_preview_component.rb
@@ -46,10 +46,9 @@ class RenderedResultsPreviewComponent < Phlex::HTML
   end
 
   register_component do
-    component_props [
-      PhlexStorybook::Props::Text.new(key: :html, placeholder: "HTML", required: true),
-    ]
-    component_stories "Short Doc" => { html: short_html }, "Long Doc" => { html: long_html }
+    prop_text :html, placeholder: "HTML", required: true
+    story "Short Doc", html: short_html
+    story "Long Doc", html: long_html
   end
 
   def initialize(html:)

--- a/test/dummy/app/components/rendered_results_preview_component.rb
+++ b/test/dummy/app/components/rendered_results_preview_component.rb
@@ -45,7 +45,7 @@ class RenderedResultsPreviewComponent < Phlex::HTML
     HTML
   end
 
-  register_component do
+  storybook do
     prop_text :html, placeholder: "HTML", required: true
     story "Short Doc", html: short_html
     story "Long Doc", html: long_html

--- a/test/dummy/app/components/storyless_component.rb
+++ b/test/dummy/app/components/storyless_component.rb
@@ -3,7 +3,7 @@
 class StorylessComponent < Phlex::HTML
   include PhlexStorybook::DSL
 
-  register_component do
+  storybook do
     category "Category 1"
     description "This is a storyless component"
     name "Component without stories"

--- a/test/dummy/app/components/storyless_component.rb
+++ b/test/dummy/app/components/storyless_component.rb
@@ -4,13 +4,11 @@ class StorylessComponent < Phlex::HTML
   include PhlexStorybook::DSL
 
   register_component do
-    component_category "Category 1"
-    component_description "This is a storyless component"
-    component_name "Component without stories"
-    component_props [
-      PhlexStorybook::Props::String.new(key: :header, default: "Default Header", required: true),
-      PhlexStorybook::Props::Text.new(key: :text, label: "The list"),
-    ]
+    category "Category 1"
+    description "This is a storyless component"
+    name "Component without stories"
+    prop_string :header, default: "Default Header", required: true
+    prop_text :text, label: "The list"
   end
 
   def initialize(header:, text: "ant\nbat\ncat\ndog")


### PR DESCRIPTION
- DSL is now executed within context of the register_component block
- remove redundant component_ prefixes
- improve property and story declarations